### PR TITLE
Verbose country names in location filter

### DIFF
--- a/trademapper/js/trademapper.filterform.js
+++ b/trademapper/js/trademapper.filterform.js
@@ -59,7 +59,7 @@ define(["d3"], function(d3) {
 			return fieldset;
 		},
 
-		addLocationField: function(fieldset, filters, columnName) {
+		addLocationField: function(fieldset, filters, columnName, countryCodeToName) {
 			var cName = this.columnNameToClassName(columnName);
 			var values = filters[columnName].values;
 			var textName = filters[columnName].hasOwnProperty("shortName") ? filters[columnName].shortName : columnName;
@@ -79,7 +79,7 @@ define(["d3"], function(d3) {
 					.text("Any " + textName);
 			}
 			for (var i = 0; i < values.length; i++) {
-				var textValue = values[i] ? values[i] : "<Blank " + textName + ">";
+				var textValue = countryCodeToName[values[i]] || values[i] || "<Blank " + textName + ">";
 				locationSelect.append("option")
 					.attr("value", values[i])
 					.text(textValue);
@@ -278,7 +278,7 @@ define(["d3"], function(d3) {
 			};
 		},
 
-		createFormFromFilters: function(formElement, filters) {
+		createFormFromFilters: function(formElement, filters, countryCodeToName) {
 			var i, locationFilters, locationFieldset, yearFilters,
 				categoryFilters, categoryFieldset;
 
@@ -292,7 +292,7 @@ define(["d3"], function(d3) {
 				return filters[a].locationOrder - filters[b].locationOrder;
 			});
 			for (i = 0; i < locationFilters.length; i++) {
-				this.addLocationField(locationFieldset, filters, locationFilters[i]);
+				this.addLocationField(locationFieldset, filters, locationFilters[i], countryCodeToName);
 			}
 
 			yearFilters = this.getFilterNamesForType(filters, ["year"]);

--- a/trademapper/js/trademapper.js
+++ b/trademapper/js/trademapper.js
@@ -184,7 +184,7 @@ define(
 		// generate the form for playing with the data
 		this.filterFormElement.html(filterSkeleton);
 
-		filterform.createFormFromFilters(this.filterFormElement, filters);
+		filterform.createFormFromFilters(this.filterFormElement, filters, mapper.countryCodeToName);
 	},
 
 	filterLoadedCallback: function(csvType, csvData, filters) {

--- a/trademapper/js/trademapper.mapper.js
+++ b/trademapper/js/trademapper.mapper.js
@@ -1,4 +1,3 @@
-
 define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], function(d3, topojson, mapdata, disputedareas, countryCentre) {
 	"use strict";
 
@@ -10,6 +9,7 @@ define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], functio
 	svgDefs: null,
 	config: null,
 	countries: null,
+	countryCodeToName: null,
 	borders: null,
 	disputed: null,
 	disputedborders: null,
@@ -29,6 +29,17 @@ define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], functio
 		this.addPatternDefs();
 		this.drawMap();
 		this.setupZoom();
+		this.makeCountryNameHash();
+	},
+
+	makeCountryNameHash: function(){
+		console.log('making hash');
+		var hash = {};
+		this.countries.forEach(function(e){
+			hash[e.id]=e.properties.name;
+		})
+		this.countryCodeToName = hash;
+		console.log(this.countryCodeToName);
 	},
 
 	drawMap: function() {


### PR DESCRIPTION
When initializing mapper, create countryCodeToName hash using the data in worldmap. trademapper.js passes this hash to filterform. filterform uses the countryCodeToName hash to set textValue in addLocationField.
