### PR TITLE
Format legend value to billion, million or thousand

### DIFF
--- a/trademapper/js/trademapper.arrows.js
+++ b/trademapper/js/trademapper.arrows.js
@@ -491,6 +491,22 @@ define(["d3", "spiralTree", "trademapper.route", "util"], function(d3, flowmap, 
 			.attr("class", "legend tradenode-label")
 			.text(roleLabel);
 	},
+
+	formatLegendValue: function(labelValue) {
+	var abs = Math.abs(Number(labelValue))
+		return abs >= 1.0e+9
+			? (abs / 1.0e+9).toFixed(0) + "B"
+			// Six Zeroes for Millions
+			: abs >= 1.0e+6
+
+			? (abs / 1.0e+6).toFixed(0) + "M"
+			// Three Zeroes for Thousands
+			: abs >= 1.0e+3
+
+			? (abs / 1.0e+3).toFixed(0) + "K"
+
+			: abs.toFixed(0);
+ 	},
 	
 	drawLegend: function() {
 		// use parseFloat as the height has "px" at the end
@@ -531,7 +547,7 @@ define(["d3", "spiralTree", "trademapper.route", "util"], function(d3, flowmap, 
 				strokeWidth = this.minArrowWidth;
 				value = (this.maxQuantity * this.minArrowWidth) / this.maxArrowWidth;
 			}
-			valueText = value.toFixed(0);
+			valueText = this.formatLegendValue(value);
 			if (i === 3) {
 				valueText = "< " + valueText;
 			}


### PR DESCRIPTION
Before:
![screenshot - 271114 - 21 45 59](https://cloud.githubusercontent.com/assets/581607/5221593/d5d6e1dc-767e-11e4-831d-9dc4ce61152e.png)

After:
![screenshot - 271114 - 21 47 49](https://cloud.githubusercontent.com/assets/581607/5221600/1295a950-767f-11e4-8ca0-085c9d108b2d.png)

Values are rounded up, but a possible improvement could be to show one or two decimals for amounts with less than two digits after formatting (example 1,4B instead of 1B or 2,8B instead of 3B)
