### PR TITLE
Apply zoom behaviour to whole SVG. Applying to zoomgroup was causing …

### DIFF
--- a/trademapper/js/trademapper.js
+++ b/trademapper/js/trademapper.js
@@ -166,7 +166,7 @@ function($, d3, arrows, csv, filterform, mapper, route, yearslider, util,
 
 		// need to init mapper before arrows otherwise the map is on top of
 		// the arrows
-		mapper.init(this.zoomg, this.controlg, this.svgDefs, this.config);
+		mapper.init(this.zoomg, this.controlg, this.svgDefs, this.config, this.tmsvg);
 		arrows.init(this.tmsvg, this.zoomg, this.svgDefs, '#maptooltip', this.config.arrowColours,
 			this.config.minArrowWidth, this.config.maxArrowWidth, this.config.pointTypeSize,
 			mapper.countryCodeToInfo);

--- a/trademapper/js/trademapper.mapper.js
+++ b/trademapper/js/trademapper.mapper.js
@@ -8,6 +8,7 @@ define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], functio
 	controlg: null,
 	svgDefs: null,
 	config: null,
+	svg: null,
 	countries: null,
 	countryCodeToName: null,
 	countryCodeToInfo: null,
@@ -23,11 +24,12 @@ define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], functio
 	 * caches svg reference
 	 * decodes countries and borders and draws them
 	 */
-	init: function(svgZoomg, controlg, svgDefs, mapConfig) {
+	init: function(svgZoomg, controlg, svgDefs, mapConfig, svg) {
 		this.zoomg = svgZoomg;
 		this.controlg = controlg;
 		this.svgDefs = svgDefs;
 		this.config = mapConfig;
+		this.svg = svg;
 		this.width = mapConfig.width  || 960;
 	 this.height = mapConfig.height  || 400;
 		this.addPatternDefs();
@@ -142,7 +144,7 @@ define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], functio
 		 .size([this.width,this.height])
 			.scaleExtent([0.5, 20])
 			.on("zoom", zoomed);
-		this.zoomg.call(zoom);
+			this.svg.call(zoom);
 
 		// and add some controls to allow zooming - html or svg?
 		// add + and - text bits, function to change the scale thing


### PR DESCRIPTION
…jittery panning

The 'zoom' event is fired many times when the user is panning and zooming. If zoom behaviour is applied to the same element as the one we are transforming their are two conflicting sources of updates to the d3.event.translate values (one from the .attr('transform',...) and one from the zoom behaviour).

I think this fixes #42 
