### PR TITLE
duncanfwalker jitter fix + test fix

### DIFF
--- a/tests/js/test-mapper.js
+++ b/tests/js/test-mapper.js
@@ -16,7 +16,7 @@ define(
               width: 1200, // parseInt(this.newsvg.style('width')),
               height: 600// parseInt(this.newsvg.style('height'))
             };
-            mapper.init(zoomg, controlg, svgdefs, config);
+            mapper.init(zoomg, controlg, svgdefs, config, newsvg);
           }
         });
 

--- a/trademapper/js/trademapper.js
+++ b/trademapper/js/trademapper.js
@@ -166,7 +166,7 @@ function($, d3, arrows, csv, filterform, mapper, route, yearslider, util,
 
 		// need to init mapper before arrows otherwise the map is on top of
 		// the arrows
-		mapper.init(this.zoomg, this.controlg, this.svgDefs, this.config);
+		mapper.init(this.zoomg, this.controlg, this.svgDefs, this.config, this.tmsvg);
 		arrows.init(this.tmsvg, this.zoomg, this.svgDefs, '#maptooltip', this.config.arrowColours,
 			this.config.minArrowWidth, this.config.maxArrowWidth, this.config.pointTypeSize,
 			mapper.countryCodeToInfo);

--- a/trademapper/js/trademapper.mapper.js
+++ b/trademapper/js/trademapper.mapper.js
@@ -8,6 +8,7 @@ define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], functio
 	controlg: null,
 	svgDefs: null,
 	config: null,
+	svg: null,
 	countries: null,
 	countryCodeToName: null,
 	countryCodeToInfo: null,
@@ -23,11 +24,12 @@ define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], functio
 	 * caches svg reference
 	 * decodes countries and borders and draws them
 	 */
-	init: function(svgZoomg, controlg, svgDefs, mapConfig) {
+	init: function(svgZoomg, controlg, svgDefs, mapConfig, svg) {
 		this.zoomg = svgZoomg;
 		this.controlg = controlg;
 		this.svgDefs = svgDefs;
 		this.config = mapConfig;
+		this.svg = svg;
 		this.width = mapConfig.width  || 960;
 	 this.height = mapConfig.height  || 400;
 		this.addPatternDefs();
@@ -142,7 +144,7 @@ define(["d3", "topojson", "worldmap", "disputedareas", "countrycentre"], functio
 		 .size([this.width,this.height])
 			.scaleExtent([0.5, 20])
 			.on("zoom", zoomed);
-		this.zoomg.call(zoom);
+			this.svg.call(zoom);
 
 		// and add some controls to allow zooming - html or svg?
 		// add + and - text bits, function to change the scale thing


### PR DESCRIPTION
This supersedes https://github.com/trademapper/trademapper-js/pull/52, including the commits from that PR + a fix for a test which breaks.

Note that there is a minor bug mentioned in the original PR, where the legend also zooms in and out with the map. However, this behaviour doesn't seem to be occurring any more, so may have either been fixed in the original commit or by some other change.