### PR TITLE
Use the transform in the zoom event unchanged

### DIFF
--- a/trademapper/js/trademapper.mapper.js
+++ b/trademapper/js/trademapper.mapper.js
@@ -229,11 +229,6 @@ define(["d3", "topojson", "vendor/doT", "worldmap", "disputedareas", "countrycen
 			var translate = [d3.event.transform.x, d3.event.transform.y];
 			var scale = d3.event.transform.k;
 
-			console.log("PRE: scale: " + scale + " translate: " + translate);
-			translate[0] = Math.max(-(moduleThis.width/2)*scale, Math.min((moduleThis.width/2)*scale, translate[0]));
-			translate[1] = Math.max(-(moduleThis.height/2)*scale, Math.min((moduleThis.height/2)*scale, translate[1]));
-			console.log("POST: translate: " + translate);
-
 			moduleThis.zoomg.attr("transform", "translate(" + translate + ")scale(" + scale + ")");
 			d3.selectAll(".country-border").attr("stroke-width", (1/scale).toString());
 			// change the width of the paths after zoom


### PR DESCRIPTION
Removing the max setting for the translation has the following
benefits:

1. The panning works when zoomed in. Before, if you zoomed right
in, you wouldn't be able to pan left and right as the zoom
area was reduced artificially.
2. When you export the animated gif, just the area you are zoomed
in on is exported. You also get fewer odd artifacts caused
by being zoomed in on part of the map.
3. The legend and year counter seem to be more consistently
positioned and don't get chopped off.

The down sides:

1. When you export SVG, you get the whole SVG, not just the
zoomed-in part of it. But this could be fixed by providing a
PNG export, which should work the same way as the GIF export
(i.e. draw to a canvas, which should show just the zoomed in part,
as happens for the GIF frames).